### PR TITLE
Quick fix for the menu's to correct the Avalanche Year

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
 		if (currentMonth == 'October'||'November'||'December') {
 			currentAviYear = currentYear;}
 		else {
-			currentAviYear = currentYear-1;
+			currentAviYear = currentYear;
 		}
 	}
 	findAvalancheYear()
@@ -1376,23 +1376,23 @@ function onEachFeatureLocationPts(feature, layer) {
 	 	}
 	
 	//Sets the dropdowns and ranges for the date range picker
-	// console.log("Current Avi Year: ", currentAviYear);
+console.log("Current Avi Year: ", currentAviYear);
 
 	$('#reportrange').daterangepicker({
 		"showDropdowns": false,
 		// October 1 thru Sept 30, currentAviYear
 		"startDate": moment(currentAviYear + '/10/01').subtract(5, 'years'),
-		"endDate": moment((currentAviYear + 1) + '/9/30'),
+		"endDate": moment(currentAviYear + '/9/30'),
 		locale: {
       		format: 'MM/DD/YYYY'
    		 },
 		//autoUpdateInput: false,
 		ranges: {
 				'Last 5 Avalanche Years': [moment(currentAviYear + '/10/01').subtract(5, 'years'), moment((currentAviYear + 1) + '/9/30')],
-				'Current Avalanche Year': [moment(currentAviYear + '/10/01'), moment((currentAviYear + 1) + '/9/30')],
-				'Last Avalanche Year': [moment(currentAviYear + '/10/01').subtract(1, 'years'), moment(currentAviYear + '/9/30')],
-				'Last 10 Avalanche Years': [moment(currentAviYear + '/10/01').subtract(10, 'years'), moment((currentAviYear + 1) + '/9/30')],
-				'All': [moment('2008-01-01'), moment((currentAviYear + 1) + '/9/30')],
+				'Current Avalanche Year': [moment((currentAviYear - 1) + '/10/01'), moment((currentAviYear) + '/9/30')],
+				'Last Avalanche Year': [moment((currentAviYear) + '/10/01').subtract(2, 'years'), moment((currentAviYear - 1) + '/9/30')],
+				'Last 10 Avalanche Years': [moment(currentAviYear + '/10/01').subtract(10, 'years'), moment((currentAviYear) + '/9/30')],
+				'All': [moment('2008-01-01'), moment((currentAviYear) + '/9/30')],
 				},
 				//maxDate: moment()
 		}, 


### PR DESCRIPTION
This is a temporary fix. The logic does not appear to be correct near lines 299-309. Need to talk to data to implement the correct fix. An avalanche year round from 10-1-YYYY to 9-30-YYYY and is identified by the YYYY date of the 9-30-YYYY